### PR TITLE
add platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,22 @@
+;PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+workspace_dir=build
+src_dir=grbl
+include_dir=grbl
+
+[env:megaatmega2560]
+platform = atmelavr
+board = megaatmega2560
+framework = arduino
+upload_port=/dev/ttyACM0
+
+


### PR DESCRIPTION
Add support file for platformio, which allows building of the project without using the Arduino IDE

https://platformio.org

Adding support involves adding a single file which provides information about building and uploading. 

to build the project: 

$cd grbl-Mega   
$platformio run

to build and upload
$cd grbl-Mega
$platformio run --target upload

Platform io reduces the upload size by only linking in those parts of the Arduino framework that are actually used in the project. 

Adding this file has no impact on the project other than to allow it to be built without the arduino iDE

